### PR TITLE
A (semi-) fix of issue #2

### DIFF
--- a/cropper.py
+++ b/cropper.py
@@ -51,13 +51,6 @@ class Rectangle:
             self.upper < other_rectangle.upper and
             self.lower > other_rectangle.lower)
 
-    def intersection(self, other_rectangle):
-        return Rectangle(
-            max(self.left, other_rectangle.left),
-            max(self.upper, other_rectangle.upper),
-            min(self.right, other_rectangle.right),
-            min(self.lower, other_rectangle.lower))
-
     def pad_to_fill(self, image: Image, pad_color=(255, 255, 255)):
         """Pad the image until it fills the rectangle. Position of the
         original image will be relative to the rectangle: if the (left,

--- a/cropper.py
+++ b/cropper.py
@@ -4,7 +4,6 @@ from PIL import Image, ImageDraw
 
 ASPECT_RATIO = 0.82690187431  # 1500 / 1814
 WIDTH_PADDING = 100  # How much extra width to add to each side of the cropped image
-STRICT_ASPECT_RATIO = True  # Force the cropped image strictly to the aspect ratio
 
 
 class Rectangle:
@@ -110,17 +109,6 @@ def crop(image: Image, product_finder: Callable[[Image], Rectangle]):
     product: Rectangle = product_finder(image)
     image_border = Rectangle.border(image)
     cropped = _calculate_crop_rectangle(product, image_border)
-
-    return cropped.pad_to_fill(image)
-
-
-def draw_crop_rectangle(image: Image, product_finder: Callable[[Image], Rectangle]):
-    product: Rectangle = product_finder(image)
-    image_border = Rectangle.border(image)
-    cropped = _calculate_crop_rectangle(product, image_border)
-
-    if image_border.encloses(cropped):
-        return cropped.draw(image)
 
     return cropped.pad_to_fill(image)
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from PIL import Image
 import os
-from cropper import crop, draw_crop_rectangle
+from cropper import crop
 from uniform_background import uniform_background_product_finder
 
 

--- a/main.py
+++ b/main.py
@@ -9,15 +9,16 @@ def main(filename):
         # TODO: The same cropping function `crop` can be used with other
         # "product finders". Here uses just the product finder for a simple
         # uniform white background.
-        drawn_crop_rectangle = draw_crop_rectangle(img, uniform_background_product_finder)
-        drawn_crop_rectangle.show()
+        cropped = crop(img, uniform_background_product_finder)
+        cropped.show()
 
-        return cropped_image
+        return cropped
+
 
 def multiple(inputdir, outputdir=None):
     if outputdir is not None:
         if not os.path.exists(outputdir): os.mkdir(outputdir)
-        
+
     for filename in os.listdir(inputdir):
         if filename.endswith(".jpg") or filename.endswith(".png"):
             image = main(inputdir + "/" + filename)


### PR DESCRIPTION
Issue #2 is a bit tricky.... Here is a suggestion for how it may be solved in some of the simpler cases :slightly_smiling_face: Whether this is the right solution or not depends on what the "correct" way to crop those images is. Test it out and decide if it should work this way, or if we should go for something else :+1: 

### Details:

This solution is strict about the aspect ratio, so the images always
come out in 1500:1814. The way it does this is by adding padding to
the images, to enforce the aspect ratio. This padding is per now
white, which means the current solution only works for images with a
uniform white background. To make this padding look as natural as
possible some logic is needed to decide which edges the product is
touching, and then add padding only to the OTHER edges. There is
likely some untested edge cases where this will break. The padding
means the products will no longer be centered.

This new solution seems to work nicely with all the
`Adidas-Advantage-Sneakers_484619_10` images as well as with the
`Adidas-Terrex-Trail-LS-T-shirt_484421_48` images. Have not tested any
other images, so it will probably break in more tricky cases!